### PR TITLE
Add stale entity detection and configurable availability mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The base options are the same as the mqtt_statestream one.
 | unique_entity_prefix | none    | no       | Prefix applied to the entity_id of the created entity                              |
 | republish_time       | 5 mins  | no       | Sets the time between iterations of republishing discovery/state for all entities. |
 | stale_after          | none    | no       | Marks entities unavailable after the configured reporting timeout.                 |
+| availability_mode    | latest  | no       | Sets availability handling to `latest`, `all`, or `any`.                           |
 | include / exclude    | none    | no       | Configure which integrations should be included / excluded from publishing.        |
 | local_status         | none    | no       | See below                                                                          |
 | remote_status        | none    | no       | See below                                                                          |

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The base options are the same as the mqtt_statestream one.
 | unique_prefix        | mqtt    | no       | Prefix applied to the unique id of the created entity                              |
 | unique_entity_prefix | none    | no       | Prefix applied to the entity_id of the created entity                              |
 | republish_time       | 5 mins  | no       | Sets the time between iterations of republishing discovery/state for all entities. |
+| stale_after          | none    | no       | Marks entities unavailable after the configured reporting timeout.                 |
 | include / exclude    | none    | no       | Configure which integrations should be included / excluded from publishing.        |
 | local_status         | none    | no       | See below                                                                          |
 | remote_status        | none    | no       | See below                                                                          |

--- a/custom_components/mqtt_discoverystream_alt/const.py
+++ b/custom_components/mqtt_discoverystream_alt/const.py
@@ -66,6 +66,7 @@ CONF_PUBLISH_DISCOVERY = "publish_discovery"
 CONF_PUBLISH_RETAIN = "publish_retain"
 CONF_REMOTE_STATUS = "remote_status"
 CONF_REPUBLISH_TIME = "republish_time"
+CONF_STALE_AFTER = "stale_after"
 CONF_UNIQUE_PREFIX = "unique_prefix"
 CONF_UNIQUE_ENTITY_PREFIX = "unique_entity_prefix"
 

--- a/custom_components/mqtt_discoverystream_alt/discovery.py
+++ b/custom_components/mqtt_discoverystream_alt/discovery.py
@@ -97,6 +97,10 @@ class Discovery:
         self.subscribe_possible = False
         self._error_domain = []
         self._unique_prefix = self._conf.get(CONF_UNIQUE_PREFIX)
+        self._availability_mode = self._conf.get(
+            CONF_AVAILABILITY_MODE,
+            AVAILABILITY_LATEST,
+        )
 
     async def async_discovery_publish(self, entity_id, attributes, mybase):
         """Publish Discovery information for entitiy."""
@@ -181,7 +185,7 @@ class Discovery:
             CONF_STATE_TOPIC: build_topic(ATTR_STATE),
             CONF_JSON_ATTRS_TOPIC: build_topic(ATTR_ATTRIBUTES),
             CONF_AVAILABILITY: availability,
-            CONF_AVAILABILITY_MODE: AVAILABILITY_LATEST,
+            CONF_AVAILABILITY_MODE: self._availability_mode,
         }
         name = None
         if ATTR_FRIENDLY_NAME in entity_info.attributes:

--- a/custom_components/mqtt_discoverystream_alt/discovery.py
+++ b/custom_components/mqtt_discoverystream_alt/discovery.py
@@ -6,7 +6,6 @@ import logging
 
 from homeassistant.components import mqtt
 from homeassistant.components.mqtt.const import (
-    AVAILABILITY_LATEST,
     CONF_AVAILABILITY,
     CONF_AVAILABILITY_MODE,
     CONF_CONNECTIONS,
@@ -97,10 +96,7 @@ class Discovery:
         self.subscribe_possible = False
         self._error_domain = []
         self._unique_prefix = self._conf.get(CONF_UNIQUE_PREFIX)
-        self._availability_mode = self._conf.get(
-            CONF_AVAILABILITY_MODE,
-            AVAILABILITY_LATEST,
-        )
+        self._availability_mode = self._conf.get(CONF_AVAILABILITY_MODE)
 
     async def async_discovery_publish(self, entity_id, attributes, mybase):
         """Publish Discovery information for entitiy."""

--- a/custom_components/mqtt_discoverystream_alt/publisher.py
+++ b/custom_components/mqtt_discoverystream_alt/publisher.py
@@ -20,12 +20,14 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entityfilter import convert_include_exclude_filter
 from homeassistant.helpers.event import async_call_later
 from homeassistant.setup import async_when_setup
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_BASE_TOPIC,
     CONF_ONLINE_STATUS,
     CONF_REMOTE_STATUS,
     CONF_REPUBLISH_TIME,
+    CONF_STALE_AFTER,
     DEFAULT_STATE_SLEEP,
 )
 from .discovery import Discovery
@@ -43,6 +45,7 @@ class Publisher:
         self._publish_retain = publish_retain
         self._conf = conf
         self._remote_status, self._remote_status_topic = self._set_remote_status()
+        self._stale_after = self._conf.get(CONF_STALE_AFTER)
         self.discovery = Discovery(self._hass, self._conf)
         self._entity_states = {}
         self._publish_filter = convert_include_exclude_filter(self._conf)
@@ -64,7 +67,7 @@ class Publisher:
         if not valid:
             return
 
-        if new_state.state in (STATE_UNAVAILABLE, None):
+        if new_state.state in (STATE_UNAVAILABLE, None) or self._state_is_stale(new_state):
             await self._async_mqtt_publish(
                 mybase, CONF_AVAILABILITY, DEFAULT_PAYLOAD_NOT_AVAILABLE
             )
@@ -160,6 +163,17 @@ class Publisher:
             self._conf.get(CONF_REPUBLISH_TIME),
             self._async_schedule_publish,
         )
+
+    def _state_is_stale(self, state):
+        if self._stale_after is None:
+            return False
+
+        last_reported = getattr(state, "last_reported", None)
+
+        if last_reported is None:
+            return False
+
+        return dt_util.utcnow() - last_reported > self._stale_after
 
     def _set_remote_status(self):
         remote_status = self._conf.get(CONF_REMOTE_STATUS)

--- a/custom_components/mqtt_discoverystream_alt/schema.py
+++ b/custom_components/mqtt_discoverystream_alt/schema.py
@@ -4,8 +4,8 @@ import voluptuous as vol
 
 from homeassistant.components.mqtt import valid_publish_topic
 from homeassistant.components.mqtt.const import (
-    AVAILABILITY_MODES,
     AVAILABILITY_LATEST,
+    AVAILABILITY_MODES,
     CONF_AVAILABILITY_MODE,
     CONF_TOPIC,
     DEFAULT_PAYLOAD_AVAILABLE,

--- a/custom_components/mqtt_discoverystream_alt/schema.py
+++ b/custom_components/mqtt_discoverystream_alt/schema.py
@@ -4,6 +4,9 @@ import voluptuous as vol
 
 from homeassistant.components.mqtt import valid_publish_topic
 from homeassistant.components.mqtt.const import (
+    AVAILABILITY_MODES,
+    AVAILABILITY_LATEST,
+    CONF_AVAILABILITY_MODE,
     CONF_TOPIC,
     DEFAULT_PAYLOAD_AVAILABLE,
     DEFAULT_PAYLOAD_NOT_AVAILABLE,
@@ -63,6 +66,10 @@ BASE_SCHEMA = {
     vol.Optional(CONF_UNIQUE_ENTITY_PREFIX): cv.string,
     vol.Optional(CONF_REPUBLISH_TIME, default=DEFAULT_REFRESH_TIME): cv.time_period,
     vol.Optional(CONF_STALE_AFTER): cv.time_period,
+    vol.Optional(
+        CONF_AVAILABILITY_MODE,
+        default=AVAILABILITY_LATEST,
+    ): vol.In(AVAILABILITY_MODES),
 }
 
 

--- a/custom_components/mqtt_discoverystream_alt/schema.py
+++ b/custom_components/mqtt_discoverystream_alt/schema.py
@@ -24,6 +24,7 @@ from .const import (
     CONF_PUBLISH_TIMESTAMPS,
     CONF_REMOTE_STATUS,
     CONF_REPUBLISH_TIME,
+    CONF_STALE_AFTER,
     CONF_UNIQUE_ENTITY_PREFIX,
     CONF_UNIQUE_PREFIX,
     DEFAULT_REFRESH_TIME,
@@ -61,6 +62,7 @@ BASE_SCHEMA = {
     vol.Optional(CONF_UNIQUE_PREFIX, default="mqtt"): cv.string,
     vol.Optional(CONF_UNIQUE_ENTITY_PREFIX): cv.string,
     vol.Optional(CONF_REPUBLISH_TIME, default=DEFAULT_REFRESH_TIME): cv.time_period,
+    vol.Optional(CONF_STALE_AFTER): cv.time_period,
 }
 
 


### PR DESCRIPTION
Adds `stale_after` support to mark entities unavailable when they stop reporting, and makes MQTT `availability_mode` configurable while preserving `latest` as the default.